### PR TITLE
reduce RPC size to get exports from sysProcessPrxInfo

### DIFF
--- a/PS3 Toolbox/PS3RPC.cs
+++ b/PS3 Toolbox/PS3RPC.cs
@@ -152,7 +152,7 @@ namespace PS3_SPRX_Loader {
                     return true;
                 }
 
-                PS3.SetMemory(RPC_BASE, new byte[0x1B0]);
+                PS3.SetMemory(RPC_BASE, new byte[0x100]);
 
                 ulong PC = 0;
                 ulong[] Registers = new ulong[0x49];


### PR DESCRIPTION
reducing the size allows us to use 0x101DC or 0x101E4 to get imports or exports functions